### PR TITLE
Update format of Discord webhook

### DIFF
--- a/functions/common/methods.ts
+++ b/functions/common/methods.ts
@@ -799,28 +799,21 @@ export const sendBikeTagPostNotificationToWebhook = (
     case 'discord':
       // https://discord.com/developers/docs/resources/webhook
       data = JSON.stringify({
-        content: `A new BikeTag has been posted!\r\nTag #${winningTagnumber} by ${tag.mysteryPlayer} \r\n\n[View previous round](${host}/${currentNumber})`,
+        content: 'A new BikeTag has been posted!',
         embeds: [
           {
-            timestamp: getTagDate(tag.foundTime).toISOString(),
-            fields: [
-              {
-                name: `Tag #${winningTagnumber}`,
-                value: `previous location found at ${tag.foundLocation} by ${tag.foundPlayer}`,
-                inline: true,
-              },
-              {
-                name: '', // purposely left blank
-                value: ``,
-                inline: true,
-              },
-            ],
+            title": `Tag #${winningTagnumber} by ${tag.mysteryPlayer}`,
+            description": `||${newPostedBikeTag.hint}||\n\n[Previous round](${host}/${currentNumber}) found at ${tag.foundLocation} by ${tag.foundPlayer}`,
+            timestamp": getTagDate(tag.foundTime).toISOString(),
             image: {
               url: tag.mysteryImageUrl,
             },
-          },
+            thumbnail: {
+              url: tag.foundImageUrl,
+            }
+          }
         ],
-      })
+      });
       break
     case 'slack':
       data = JSON.stringify({


### PR DESCRIPTION
The two biggest issues with #166 were:
1. The second embed had an empty name which isn't allowed, so that entire section was missing
2. The timestamp was wrong, but was fixed [here](https://github.com/cookieguru/biketag-vue/commit/e0d123abe5e1a06b06ba19e64ee84a86783b474b#diff-5bed49206612356f13db304034106ee7abc6d20de6bff8b9e84fe6744e17132bR779)

I've made a few tweaks to the embed code and now [the message](https://discohook.org/?data=eyJtZXNzYWdlcyI6W3siZGF0YSI6eyJjb250ZW50IjoiQSBuZXcgQmlrZVRhZyBoYXMgYmVlbiBwb3N0ZWQhIiwiZW1iZWRzIjpbeyJ0aXRsZSI6IlRhZyAje3dpbm5pbmdUYWdudW1iZXJ9IGJ5IHt0YWcubXlzdGVyeVBsYXllcn0iLCJkZXNjcmlwdGlvbiI6Inx8e25ld1Bvc3RlZEJpa2VUYWcuaGludH18fFxuXG5bUHJldmlvdXMgcm91bmRdKGh0dHBzOi8vaG9zdC97Y3VycmVudE51bWJlcn0pIGZvdW5kIGF0IHt0YWcuZm91bmRMb2NhdGlvbn0gYnkge3RhZy5mb3VuZFBsYXllcn0iLCJjb2xvciI6bnVsbCwidGltZXN0YW1wIjoiMjAyMy0xMi0yNVQxMjozNDo1Ni43ODlaIiwiaW1hZ2UiOnsidXJsIjoiaHR0cHM6Ly9pLmltZ3VyLmNvbS9mTmRrMUlyLmpwZyJ9LCJ0aHVtYm5haWwiOnsidXJsIjoiaHR0cHM6Ly9pLmltZ3VyLmNvbS9FYjVSTlAwbS5qcGcifX1dLCJ1c2VybmFtZSI6IlNlYXR0bGUgQmlrZSBUYWciLCJhdmF0YXJfdXJsIjoiaHR0cHM6Ly9pLmltZ3VyLmNvbS9jdnJ5TGpJLmdpZiIsImF0dGFjaG1lbnRzIjpbXX19XX0) looks like this:

![Screenshot of updated Discord webhook](https://github.com/KenEucker/biketag-vue/assets/1888809/29baabe7-5a7b-4638-9a67-d632565d0dc4)
