### PR TITLE
Fix property checking when camera GPS data fails to decode

### DIFF
--- a/src/components/QueueFound.vue
+++ b/src/components/QueueFound.vue
@@ -394,14 +394,12 @@ const setImage = async (event) => {
         } else {
           const GPSData = await exifr.gps(await input.files[0].arrayBuffer())
 
-          if (GPSData) {
-            if (GPSData.latitude != null && GPSData.longitude != null) {
-              gps.value = {
-                lat: round(GPSData.latitude),
-                lng: round(GPSData.longitude),
-              }
-              isGpsDefault.value = false
+          if (GPSData && gpsData.latitude && GPSData.longitude) {
+            gps.value = {
+              lat: round(GPSData.latitude),
+              lng: round(GPSData.longitude),
             }
+            isGpsDefault.value = false
           } else {
             gps.value = getGame.value?.boundary
             isGpsDefault.value = true


### PR DESCRIPTION
When a file's GPS EXIF data does not decode properly exifr returns an object with `latitude` and `longitude` properties that are both `NaN`:

![Screenshot showing GPSData variable in the debugger is a plain object with properties latitude and longitude, both of which have a value of NaN](https://github.com/KenEucker/biketag-vue/assets/1888809/38507bbc-9241-4e63-9d9c-563408abe0b4)

Since the code only checks for `null`, both values are stored.  Later, this object is passed to other methods that expect them to be numbers.

This commit eschews the null checks for simple truthy checks since neither `NaN` nor `null` are [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy).