### PR TITLE
Update BikeTagFooter.vue

changes "last" to "prev".

### DIFF
--- a/src/components/BikeTagFooter.vue
+++ b/src/components/BikeTagFooter.vue
@@ -3,7 +3,7 @@
     <div ref="root" :class="[props.variant, 'button-group']">
       <div v-if="props.variant === 'current'">
         <!-- Left Button -->
-        <bike-tag-button class="button-group__left" :text="t('menu.last')" @click="emit('previous')" />
+        <bike-tag-button class="button-group__left" :text="t('menu.previous')" @click="emit('previous')" />
         <!-- Middle Button -->
         <bike-tag-button
           id="hint"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the text label for the left button in the "current" variant of the footer to display "Previous" instead of "Last".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->