### PR TITLE
feat: Add an api/stats endpoint #284

### DIFF
--- a/functions/current.ts
+++ b/functions/current.ts
@@ -34,7 +34,8 @@ const currentTagHandler = async (event) => {
     const currentTag = currentTagResponse.data
     const data: any = currentTag
     const domainInfo = getDomainInfo(event)
-    data.host = 'i.imgur.com'
+    const host = 'i.imgur.com'
+    data.host = domainInfo.host
     data.imageUri = getImgurImageSized(data.mysteryImageUrl, biketagPayload.size)
 
     if (biketagPayload.data) {
@@ -49,6 +50,9 @@ const currentTagHandler = async (event) => {
         (
           await axios.get(data.imageUri, {
             responseType: 'arraybuffer',
+            headers: {
+              host,
+            },
           })
         ).data,
         'utf-8',

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -29,15 +29,15 @@ function getIsSameDay(
 function getPlayerHighestNumberTagsPerDayData(
   player: Player
 ): {} {
-  let tagsPerDayData : {} = {
+  let tagsPerDayData: {} = {
     'tagCount': 0,
     'tagDate': new Date()
   };
-  let tagsPerDay : number = 1;
-  let tagsPerDayHighest : number = 1;
-  let previousTagDate : Date | null = null;
+  let tagsPerDay: number = 1;
+  let tagsPerDayHighest: number = 1;
+  let previousTagDate: Date | null = null;
   for (const tag of player.tags) {
-    const tagDate : Date = getTagDate(tag.mysteryTime);
+    const tagDate: Date = getTagDate(tag.mysteryTime);
     if (previousTagDate != null && getIsSameDay(tagDate, previousTagDate)) {
       tagsPerDay++;
     } else {
@@ -45,8 +45,9 @@ function getPlayerHighestNumberTagsPerDayData(
     }
     if (tagsPerDay > tagsPerDayHighest) {
       tagsPerDayData = {
+        'playerName': player.name,
         'tagCount': tagsPerDay,
-        'tagDate': tagDate
+        'tagDate': tagDate,
       }
     }
     previousTagDate = tagDate;
@@ -62,16 +63,16 @@ function getPlayerHighestNumberTagsPerDayData(
 function getPlayersWithHighestNumberTagsPerDayData(
   players: Player[]
 ): Array<{}> {
-  let tagsPerDayHighest : number = 0;
-  let tagsPerDayData : Array<{}> = [];
+  let tagsPerDayHighest: number = 0;
+  let tagsPerDayData: Array<{}> = [];
   for (const player of players) {
-    const tagsPerDayRecord : {} = getPlayerHighestNumberTagsPerDayData(player);
+    const tagsPerDayRecord: {} = getPlayerHighestNumberTagsPerDayData(player);
     tagsPerDayData.push(tagsPerDayRecord);
     if (tagsPerDayRecord['tagCount'] > tagsPerDayHighest) {
       tagsPerDayHighest = tagsPerDayRecord['tagCount'];
     }
   }
-  let highestTagsPerDayData : Array<{}> = [];
+  let highestTagsPerDayData: Array<{}> = [];
   for (const tpdr of tagsPerDayData) {
     if (tpdr['tagCount'] >= tagsPerDayHighest) {
       highestTagsPerDayData.push(tpdr);
@@ -88,19 +89,22 @@ function getPlayersWithHighestNumberTagsPerDayData(
 function getPlayerUniqueTagDates(
   player: Player
 ): Date[] {
-  let uniqueTagDates : Date[] = [];
+  let uniqueTagDates: Date[] = [];
   for (const tag of player.tags) {
-      const tagDate : Date = getTagDate(tag.mysteryTime);
-      if (uniqueTagDates.length === 0) {
+    if (tag.mysteryTime === 0) {
+      // There are some mysteryTime entries with 0 value. Ignore them.
+      continue;
+    }
+    const tagDate: Date = getTagDate(tag.mysteryTime);
+    if (uniqueTagDates.length === 0) {
+      uniqueTagDates.push(tagDate);
+    } else {
+      const isAlreadyPresent = uniqueTagDates.some(date => getIsSameDay(date, tagDate));
+      if (!isAlreadyPresent) {
         uniqueTagDates.push(tagDate);
-      } else {
-        for (const utd of uniqueTagDates) {
-          if (!getIsSameDay(utd, tagDate)) {
-            uniqueTagDates.push(tagDate);
-          }
-        }
       }
     }
+  }
   return uniqueTagDates;
 }
 
@@ -112,37 +116,49 @@ function getPlayerUniqueTagDates(
 function getPlayerTagLongestStreakData(
   player: Player
 ): {} {
-  let tagDates : Date[] = getPlayerUniqueTagDates(player);
+  let tagDates: Date[] = getPlayerUniqueTagDates(player);
   tagDates.sort((a, b) => a.getTime() - b.getTime());
-  let streakDaysCount : number | null = null;
-  let streakStartDate : Date | null = null;
-  let streakEndDate : Date | null = null;
-  let onStreak : boolean = false;
+  let streakDaysCount: number = 1;
+  let streakDaysCountLongest: number = 1;
+  let streakStartDate: Date | null = null;
+  let streakEndDate: Date | null = null;
+  let onActualStreak: boolean = false;
+  const oneDay: number = (24 * 60 * 60 * 1000) * 1;
   for (const td of tagDates) {
-    const tagDateMinusOneDay : Date = new Date(td.getDate() - 1);
-    const index : number = tagDates.indexOf(td);
+    if (!onActualStreak) {
+      streakStartDate = td;
+      streakEndDate = td;
+    }
+    const index: number = tagDates.indexOf(td);
     if (index === 0) {
+      // Need a previous date to compare with, skip the first
       continue;
     } else {
-      const indexMinusOneDate = tagDates[index-1]
+      // Determine if an actual (more than 1 day) streak started: Calculate the current tag 
+      // mysteryTime minus one day, check if same date as previous array tag mysteryTime
+      const tagDateMinusOneDay: Date = new Date();
+      tagDateMinusOneDay.setTime(td.getTime() - oneDay);
+      const indexMinusOneDate = tagDates[index - 1]
       if (getIsSameDay(tagDateMinusOneDay, indexMinusOneDate)) {
-        if (!onStreak) {
+        if (!onActualStreak) {
           streakStartDate = indexMinusOneDate;
         }
         streakEndDate = td;
-        onStreak = true;
+        onActualStreak = true;
+        if (streakStartDate != null && streakEndDate != null) {
+          // Calculate streak days, including both end dates
+          const diffTime = streakEndDate.getTime() - streakStartDate.getTime();
+          streakDaysCount = Math.round(diffTime / oneDay) + 1;
+          if (streakDaysCount > streakDaysCountLongest) {
+            streakDaysCountLongest = streakDaysCount;
+          }
+        }
       } else {
-        onStreak = false;
+        onActualStreak = false;
       }
     }
   }
-  if (streakStartDate != null && streakEndDate != null) {
-    const oneDay = 24 * 60 * 60 * 1000;
-    const diffTime = streakEndDate.getTime() - streakStartDate.getTime();
-    streakDaysCount = Math.round(diffTime / oneDay) + 1;
-  }
-
-  const streakData : {} = {
+  const streakData: {} = {
     'longestStreakDaysCount': streakDaysCount,
     'longestStreakStartDate': streakStartDate,
     'longestStreakEndDate': streakEndDate,
@@ -159,23 +175,23 @@ function getPlayerTagLongestStreakData(
 function getPlayersDataWithLongestStreakDaysTagged(
   players: Player[]
 ): Array<{}> {
-  let longestStreakDays : number = 0;
-  let playerRecord : {};
-  let playersData : Array<{}> = [];
+  let longestStreakDays: number = 0;
+  let playerRecord: {};
+  let playersData: Array<{}> = [];
   for (const player of players) {
     const playerLongestStreakData = getPlayerTagLongestStreakData(player)
-    if (playerLongestStreakData['streakDaysCount'] > longestStreakDays) {
+    if (playerLongestStreakData['longestStreakDaysCount'] > longestStreakDays) {
       longestStreakDays = playerLongestStreakData['longestStreakDaysCount'];
     }
     playerRecord = {
-      'player': player,
+      'playerName': player.name,
       'longestStreakData': playerLongestStreakData
     }
     playersData.push(playerRecord);
   }
-  let longestStreakPlayersData : Array<{}> = [];
+  let longestStreakPlayersData: Array<{}> = [];
   for (const pd of playersData) {
-    if (pd['longestStreakDays'] >= longestStreakDays) {
+    if (pd['longestStreakData']['longestStreakDaysCount'] >= longestStreakDays) {
       longestStreakPlayersData.push(pd);
     }
   }
@@ -190,13 +206,16 @@ function getPlayersDataWithLongestStreakDaysTagged(
 function getLongestTimeBetweenTags(
   tags: Tag[]
 ): number {
-  let longestTimeBetweenTags : number = 0;
-  let previousTag : Tag | null = null;
-  for (const tag of tags) {
-    if (longestTimeBetweenTags === 0) {
+  let longestTimeBetweenTags: number = 0;
+  let previousTag: Tag | null = null;
+  // tags.sort((a, b) => (a.tagNumber < b.tagNumber ? -1 : 1));
+  for (const tag of tags.reverse()) {
+    if (tags.indexOf(tag) === 0) {
+      // Need a previous tag to compare with. Skip the first.
+      previousTag = tag;
       continue;
     } else {
-      const timeBetweenTags : number = tag.mysteryTime - previousTag.mysteryTime
+      const timeBetweenTags: number = tag.mysteryTime - previousTag.mysteryTime
       if (timeBetweenTags > longestTimeBetweenTags) {
         longestTimeBetweenTags = timeBetweenTags;
       }
@@ -230,30 +249,28 @@ const statsHandler: Handler = async (event) => {
   const playersResponse = await biketag.getPlayers(biketagPayload as getPlayersPayload, {
     source: 'imgur',
   })
-  console.log(`getPlayers response: ${playersResponse}`);
 
   // Player(s) with most tags in one day (total, time)
-  const playersWithMostTagsInOneDayData : {} = getPlayersWithHighestNumberTagsPerDayData(playersResponse.data)
+  const playersWithMostTagsInOneDayData: {} = getPlayersWithHighestNumberTagsPerDayData(playersResponse.data)
 
   // Players with longest streak of days with a tag (total days, start time, end time)
-  const playersWithLongestTagStreakDaysData : {} = getPlayersDataWithLongestStreakDaysTagged(playersResponse.data)
+  const playersWithLongestTagStreakDaysData: {} = getPlayersDataWithLongestStreakDaysTagged(playersResponse.data)
 
   // Total number of players
-  const totalNumberOfPlayers : number = playersResponse.data.length;
+  const totalNumberOfPlayers: number = playersResponse.data.length;
 
   // Get Tags data
   const tagsResponse = await biketag.getTags(biketagPayload as getTagsPayload, {
     source: 'imgur',
   })
-  console.log(`getTags response: ${tagsResponse}`);
 
   // Total number of tags
-  const totalNumberOfTags : number = tagsResponse.data.length;
+  const totalNumberOfTags: number = tagsResponse.data.length;
 
   // Longest time between tags
-  const longestTimeBetweenTags : number = getLongestTimeBetweenTags(tagsResponse.data);
+  const longestTimeBetweenTags: number = getLongestTimeBetweenTags(tagsResponse.data);
 
-  let statusCode : number = 400;
+  let statusCode: number = 400;
   if (playersResponse.status === 200 && tagsResponse.status === 200) {
     statusCode = 200;
   }
@@ -265,7 +282,7 @@ const statsHandler: Handler = async (event) => {
     'totalNumberOfTags': totalNumberOfTags,
     'longestTimeBetweenTags': longestTimeBetweenTags
   }
-  const statsResponse : {} = {
+  const statsResponse: {} = {
     'data': data,
     'success': success,
     'error': !success ? 'Something went wrong' : undefined,

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -188,6 +188,10 @@ function getPlayersWithHighestNumberTagsPerDayData(
   let tagsPerDayData: PlayerHighestNumberTagsPerDayData[] = [];
   let highestTagsPerDayData: PlayerHighestNumberTagsPerDayData[] = [];
   for (const player of players) {
+    if (player.name === '') {
+      console.log('Player has no name, and probably no real data. Ignoring player: ', player)
+      continue;
+    }
     const tagsPerDayRecord: PlayerHighestNumberTagsPerDayData = getPlayerHighestNumberTagsPerDayData(player);
     tagsPerDayData.push(tagsPerDayRecord);
     if (tagsPerDayRecord.tagCount != null && tagsPerDayRecord.tagCount > tagsPerDayHighest) {
@@ -307,6 +311,10 @@ function getPlayersWithLongestDailyTagStreakData(
   let playerRecord: PlayerStreakData;
   let playersData: PlayerStreakData[] = [];
   for (const player of players) {
+    if (player.name === '') {
+      console.log('Player has no name, and probably no real data. Ignoring player: ', player)
+      continue;
+    }
     const playerLongestStreakData: StreakData = getTagLongestDailyStreakData(player.tags)
     if (playerLongestStreakData.longestStreakDaysCount > longestStreakDays) {
       longestStreakDays = playerLongestStreakData.longestStreakDaysCount;

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -44,9 +44,10 @@ function getPlayerHighestNumberTagsPerDayData(
       tagsPerDay = 1;
     }
     if (tagsPerDay > tagsPerDayHighest) {
+      tagsPerDayHighest = tagsPerDay;
       tagsPerDayData = {
         'playerName': player.name,
-        'tagCount': tagsPerDay,
+        'tagCount': tagsPerDayHighest,
         'tagDate': tagDate,
       }
     }

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -49,7 +49,6 @@ function getIsWithinDaysRange(
   d2: Date,
   days: number
 ): boolean {
-  const oneDay: number = (24 * 60 * 60 * 1000) * 1;
   const diffDays = getDaysDifference(d1, d2);
   return diffDays <= days;
 }

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -32,7 +32,6 @@ function getDaysDifference(
   d2: Date,
 ): number {
   const timeDiff = Math.abs(d2.getTime() - d1.getTime());
-  const dateDiff = d2.getTime() - d2.getTime();
   const oneDay: number = (24 * 60 * 60 * 1000) * 1;
   const diffDays = Math.ceil(timeDiff / oneDay);
   return diffDays;
@@ -286,8 +285,8 @@ function getTagLongestDailyStreakData(
   }
   const streakData: StreakData = {
     longestStreakDaysCount: streakDaysCountLongest,
-    longestStreakStartDate: streakLongestStartDate,
-    longestStreakEndDate: streakEndDate,
+    longestStreakStartDate: streakDaysCountLongest > 1 ? streakLongestStartDate : null,
+    longestStreakEndDate: streakDaysCountLongest > 1 ? streakEndDate : null,
   }
   return streakData;
 }

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -450,7 +450,7 @@ const statsHandler: Handler = async (event) => {
     gameLongestDailyTagStreakData: gameLongestDailyTagStreakData,
     gameLongestTimeBetweenTags: longestTimeBetweenTags
   }
-  const statsResponse: {} = {
+  const statsResponse: StatsResponse = {
     data: success ? data : undefined,
     success: success,
     error: !success ? 'Failed to retrieve stats' : undefined,

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -360,6 +360,12 @@ interface StatsReportData {
   gameLongestTimeBetweenTags: number
 }
 
+interface StatsResponse {
+  data?: StatsReportData;
+  success: boolean;
+  error?: string;
+}
+
 const statsHandler: Handler = async (event) => {
   const biketagOpts = getBikeTagClientOpts(
     {
@@ -437,13 +443,13 @@ const statsHandler: Handler = async (event) => {
     gameLongestTimeBetweenTags: longestTimeBetweenTags
   }
   const statsResponse: {} = {
-    'data': data,
-    'success': success,
-    'error': !success ? 'Something went wrong' : undefined,
+    data: success ? data : undefined,
+    success: success,
+    error: !success ? 'Failed to retrieve stats' : undefined,
   }
   return {
     statusCode: statusCode,
-    body: JSON.stringify(success ? data : statsResponse),
+    body: JSON.stringify(statsResponse),
   }
 }
 

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -109,6 +109,12 @@ function getPlayerUniqueTagDates(
   return uniqueTagDates;
 }
 
+interface StreakData {
+  longestStreakDaysCount: number;
+  longestStreakStartDate: Date | null;
+  longestStreakEndDate: Date | null;
+}
+
 /**
  * Get the player's longest streak of days with a tag data
  * @param player Player to get longest streak of days with a tag data
@@ -116,57 +122,56 @@ function getPlayerUniqueTagDates(
  */
 function getPlayerTagLongestStreakData(
   player: Player
-): {} {
+): StreakData {
   let tagDates: Date[] = getPlayerUniqueTagDates(player);
   tagDates.sort((a, b) => a.getTime() - b.getTime());
   let streakDaysCount: number = 1;
   let streakDaysCountLongest: number = 1;
   let streakStartDate: Date | null = null;
   let streakEndDate: Date | null = null;
-  let onActualStreak: boolean = false;
+  let previousDate: Date | null = null;
   const oneDay: number = (24 * 60 * 60 * 1000) * 1;
   for (const td of tagDates) {
-    if (!onActualStreak) {
-      streakStartDate = td;
-      streakEndDate = td;
-    }
     const index: number = tagDates.indexOf(td);
-    if (index === 0) {
-      // Need a previous date to compare with, skip the first
-      continue;
-    } else {
+    if (previousDate != null) {
       // Determine if an actual (more than 1 day) streak started: Calculate the current tag 
       // mysteryTime minus one day, check if same date as previous array tag mysteryTime
       const tagDateMinusOneDay: Date = new Date();
       tagDateMinusOneDay.setTime(td.getTime() - oneDay);
-      const indexMinusOneDate = tagDates[index - 1]
-      if (getIsSameDay(tagDateMinusOneDay, indexMinusOneDate)) {
-        if (!onActualStreak) {
-          streakStartDate = indexMinusOneDate;
-        }
-        streakEndDate = td;
-        onActualStreak = true;
-        if (streakStartDate != null && streakEndDate != null) {
-          // Calculate streak days, including both end dates
-          const diffTime = streakEndDate.getTime() - streakStartDate.getTime();
-          streakDaysCount = Math.round(diffTime / oneDay) + 1;
-          if (streakDaysCount > streakDaysCountLongest) {
-            streakDaysCountLongest = streakDaysCount;
+      if (getIsSameDay(tagDateMinusOneDay, previousDate)) {
+        streakDaysCount++;
+        if (streakDaysCount >= streakDaysCountLongest) {
+          if (streakDaysCount === 2) {
+            // Current streak start
+            streakStartDate = previousDate;
           }
+          // Current streak end
+          streakDaysCountLongest = streakDaysCount;
+          streakEndDate = td;
         }
       } else {
-        onActualStreak = false;
+        // The streak is over
+        streakDaysCount = 1;
       }
+    } else {
+      // Set streak start/end dates for players without an actual streak (>1 day)
+      streakStartDate = td;
+      streakEndDate = td;
     }
+    previousDate = td;
   }
-  const streakData: {} = {
-    'longestStreakDaysCount': streakDaysCount,
-    'longestStreakStartDate': streakStartDate,
-    'longestStreakEndDate': streakEndDate,
+  const streakData: StreakData = {
+    longestStreakDaysCount: streakDaysCountLongest,
+    longestStreakStartDate: streakStartDate,
+    longestStreakEndDate: streakEndDate,
   }
   return streakData;
 }
 
+interface PlayerStreakData {
+  playerName: string;
+  longestStreakData: StreakData;
+}
 
 /**
  * Get the players data with the longest streak of days tagged
@@ -175,24 +180,24 @@ function getPlayerTagLongestStreakData(
  */
 function getPlayersDataWithLongestStreakDaysTagged(
   players: Player[]
-): Array<{}> {
+): PlayerStreakData[] {
   let longestStreakDays: number = 0;
-  let playerRecord: {};
-  let playersData: Array<{}> = [];
+  let playerRecord: PlayerStreakData;
+  let playersData: PlayerStreakData[] = [];
   for (const player of players) {
     const playerLongestStreakData = getPlayerTagLongestStreakData(player)
-    if (playerLongestStreakData['longestStreakDaysCount'] > longestStreakDays) {
-      longestStreakDays = playerLongestStreakData['longestStreakDaysCount'];
+    if (playerLongestStreakData.longestStreakDaysCount > longestStreakDays) {
+      longestStreakDays = playerLongestStreakData.longestStreakDaysCount;
     }
     playerRecord = {
-      'playerName': player.name,
-      'longestStreakData': playerLongestStreakData
+      playerName: player.name,
+      longestStreakData: playerLongestStreakData
     }
     playersData.push(playerRecord);
   }
-  let longestStreakPlayersData: Array<{}> = [];
+  let longestStreakPlayersData: PlayerStreakData[] = [];
   for (const pd of playersData) {
-    if (pd['longestStreakData']['longestStreakDaysCount'] >= longestStreakDays) {
+    if (pd.longestStreakData.longestStreakDaysCount >= longestStreakDays) {
       longestStreakPlayersData.push(pd);
     }
   }
@@ -209,13 +214,9 @@ function getLongestTimeBetweenTags(
 ): number {
   let longestTimeBetweenTags: number = 0;
   let previousTag: Tag | null = null;
-  // tags.sort((a, b) => (a.tagNumber < b.tagNumber ? -1 : 1));
-  for (const tag of tags.reverse()) {
-    if (tags.indexOf(tag) === 0) {
-      // Need a previous tag to compare with. Skip the first.
-      previousTag = tag;
-      continue;
-    } else {
+  const sortedTags = [...tags].reverse();
+  for (const tag of sortedTags) {
+    if (previousTag != null) {
       const timeBetweenTags: number = tag.mysteryTime - previousTag.mysteryTime
       if (timeBetweenTags > longestTimeBetweenTags) {
         longestTimeBetweenTags = timeBetweenTags;
@@ -234,6 +235,12 @@ const statsHandler: Handler = async (event) => {
     } as unknown as request.Request,
     true,
   )
+  if (!biketagOpts.game) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ success: false, error: 'Game parameter is required' }),
+    }
+  }
   const biketag = new BikeTagClient(biketagOpts)
   const game = (await biketag.game(biketagOpts.game, {
     source: 'sanity',

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -22,16 +22,141 @@ function getIsSameDay(
 }
 
 /**
+ * Get difference in days between two Dates
+ * @param d1 Date 1
+ * @param d2 Date 2
+ * @returns Number of days betwteen two dates
+ */
+function getDaysDifference(
+  d1: Date,
+  d2: Date,
+): number {
+  const timeDiff = Math.abs(d2.getTime() - d1.getTime());
+  const dateDiff = d2.getTime() - d2.getTime();
+  const oneDay: number = (24 * 60 * 60 * 1000) * 1;
+  const diffDays = Math.ceil(timeDiff / oneDay);
+  return diffDays;
+}
+
+/**
+ * Check if two Dates are within a range of days
+ * @param d1 Date 1
+ * @param d2 Date 2
+ * @param days Number of days to check for range
+ * @returns Number of days betwteen two dates
+ */
+function getIsWithinDaysRange(
+  d1: Date,
+  d2: Date,
+  days: number
+): boolean {
+  const oneDay: number = (24 * 60 * 60 * 1000) * 1;
+  const diffDays = getDaysDifference(d1, d2);
+  return diffDays <= days;
+}
+
+interface GameHighestNumberTagsPerNumberDaysData {
+  tagCount: number;
+  dayCount: number;
+  startDate: Date | null;
+  endDate: Date | null;
+}
+/**
+ * Get game highest number of tags in specified number of days
+ * @param tags Tags to get highest number of tags in days data
+ * @param days Number of days
+ * @returns Highest number of tags per number of days data
+ */
+function getGameHighestNumberTagsPerNumberDaysData(
+  tags: Tag[],
+  days: number = 1
+): GameHighestNumberTagsPerNumberDaysData {
+  let tagsPerNumberDaysHighest: number = 1;
+  let previousTagDate: Date | null = null;
+  let startDate: Date | null = null;
+  let endDate: Date | null = null;
+  let tagDatesInRange: Tag[] = [];
+  let tagIsInRange: boolean = false;
+  let tagsPerNumberDaysData: GameHighestNumberTagsPerNumberDaysData = {
+    tagCount: tagsPerNumberDaysHighest,
+    dayCount: days,
+    startDate: previousTagDate,
+    endDate: previousTagDate
+  }
+  const oneDay: number = (24 * 60 * 60 * 1000) * 1;
+  const daysBack: number[] = [...Array(days).keys()];
+  const sortedTags = [...tags].reverse();
+  for (const tag of sortedTags) {
+    const tagDate: Date = getTagDate(tag.mysteryTime);
+    if (previousTagDate != null) {
+      if (tagDatesInRange.length === 0) {
+        // Initialize the array with the first date
+        tagDatesInRange = [previousTagDate];
+      }
+      // Clone the array so it can be modified while iterating
+      let tagDatesInRangeNew = Object.assign([], tagDatesInRange);
+      for (const dayBack of daysBack) {
+        // Calculate the date for the number of days back in time
+        const daysBackTime: number = oneDay * dayBack;
+        const tagDateMinusDayBack: Date = new Date();
+        tagDateMinusDayBack.setTime(tagDate.getTime() - daysBackTime);
+        for (const tid of tagDatesInRange) {
+          // Check if the current tagDate is within acceptable range of days
+          if (getIsWithinDaysRange(tid, tagDateMinusDayBack, days)) {
+            tagDatesInRangeNew.push(tagDate);
+            tagIsInRange = true;
+            // Quit checking if it is in acceptable range of days
+            break;
+          } else {
+            // Remove the old index that is no longer in the sliding range window
+            const indexNotInRangeDate = tagDatesInRangeNew.indexOf(tid);
+            tagDatesInRangeNew.splice(indexNotInRangeDate, 1);
+            tagIsInRange = false;
+          }
+        }
+        if (tagIsInRange) {
+          // Quit checking if it is already confirmed to be in range
+          break;
+        }
+      }
+      // Update the main array with the new one
+      tagDatesInRange = tagDatesInRangeNew;
+      if (tagDatesInRange.length >= tagsPerNumberDaysHighest) {
+        // Set stats to be reported if the previous tag number record was beat
+        tagsPerNumberDaysHighest = tagDatesInRange.length;
+        startDate = tagDatesInRange[0];
+        endDate = tagDatesInRange[tagDatesInRange.length - 1];
+      }
+    }
+    previousTagDate = tagDate;
+  }
+  tagsPerNumberDaysData = {
+    tagCount: tagsPerNumberDaysHighest,
+    dayCount: days,
+    startDate: startDate,
+    endDate: endDate
+  }
+  return tagsPerNumberDaysData;
+}
+
+interface PlayerHighestNumberTagsPerDayData {
+  playerName: string,
+  tagCount: number | null,
+  tagDate: Date | null
+}
+
+/**
  * Get player's highest number of tags in one day data
  * @param player Player to get highest number of tags in one day data
  * @returns Highest number of tags per day data
  */
 function getPlayerHighestNumberTagsPerDayData(
   player: Player
-): {} {
-  let tagsPerDayData: {} = {
-    'tagCount': 0,
-    'tagDate': new Date()
+): PlayerHighestNumberTagsPerDayData {
+  let tagsPerDayData: PlayerHighestNumberTagsPerDayData = {
+    playerName: player.name,
+    tagCount: null,
+    tagDate: null
   };
   let tagsPerDay: number = 1;
   let tagsPerDayHighest: number = 1;
@@ -45,11 +170,8 @@ function getPlayerHighestNumberTagsPerDayData(
     }
     if (tagsPerDay > tagsPerDayHighest) {
       tagsPerDayHighest = tagsPerDay;
-      tagsPerDayData = {
-        'playerName': player.name,
-        'tagCount': tagsPerDayHighest,
-        'tagDate': tagDate,
-      }
+      tagsPerDayData.tagCount = tagsPerDayHighest;
+      tagsPerDayData.tagDate = tagDate;
     }
     previousTagDate = tagDate;
   }
@@ -63,19 +185,19 @@ function getPlayerHighestNumberTagsPerDayData(
  */
 function getPlayersWithHighestNumberTagsPerDayData(
   players: Player[]
-): Array<{}> {
+): PlayerHighestNumberTagsPerDayData[] {
   let tagsPerDayHighest: number = 0;
-  let tagsPerDayData: Array<{}> = [];
+  let tagsPerDayData: PlayerHighestNumberTagsPerDayData[] = [];
+  let highestTagsPerDayData: PlayerHighestNumberTagsPerDayData[] = [];
   for (const player of players) {
-    const tagsPerDayRecord: {} = getPlayerHighestNumberTagsPerDayData(player);
+    const tagsPerDayRecord: PlayerHighestNumberTagsPerDayData = getPlayerHighestNumberTagsPerDayData(player);
     tagsPerDayData.push(tagsPerDayRecord);
-    if (tagsPerDayRecord['tagCount'] > tagsPerDayHighest) {
-      tagsPerDayHighest = tagsPerDayRecord['tagCount'];
+    if (tagsPerDayRecord.tagCount != null && tagsPerDayRecord.tagCount > tagsPerDayHighest) {
+      tagsPerDayHighest = tagsPerDayRecord.tagCount;
     }
   }
-  let highestTagsPerDayData: Array<{}> = [];
   for (const tpdr of tagsPerDayData) {
-    if (tpdr['tagCount'] >= tagsPerDayHighest) {
+    if (tpdr.tagCount != null && tpdr.tagCount >= tagsPerDayHighest) {
       highestTagsPerDayData.push(tpdr);
     }
   }
@@ -83,15 +205,15 @@ function getPlayersWithHighestNumberTagsPerDayData(
 }
 
 /**
- * Get the player's unique tag dates
- * @param player Player to get unique tag dates
+ * Get the unique tag dates
+ * @param tags Tags to get unique tag dates
  * @returns Array of unique tag dates
  */
-function getPlayerUniqueTagDates(
-  player: Player
+function getUniqueTagDates(
+  tags: Tag[]
 ): Date[] {
   let uniqueTagDates: Date[] = [];
-  for (const tag of player.tags) {
+  for (const tag of tags) {
     if (tag.mysteryTime === 0) {
       // There are some mysteryTime entries with 0 value. Ignore them.
       continue;
@@ -116,23 +238,23 @@ interface StreakData {
 }
 
 /**
- * Get the player's longest streak of days with a tag data
- * @param player Player to get longest streak of days with a tag data
- * @returns Object containing longest streak days count, streak start date, streak end date
+ * Get the longest daily tag streak data
+ * @param tags Tags to get longest streak of days with a tag data
+ * @returns StreakData
  */
-function getPlayerTagLongestStreakData(
-  player: Player
+function getTagLongestDailyStreakData(
+  tags: Tag[]
 ): StreakData {
-  let tagDates: Date[] = getPlayerUniqueTagDates(player);
+  let tagDates: Date[] = getUniqueTagDates(tags);
   tagDates.sort((a, b) => a.getTime() - b.getTime());
   let streakDaysCount: number = 1;
   let streakDaysCountLongest: number = 1;
   let streakStartDate: Date | null = null;
+  let streakLongestStartDate: Date | null = null;
   let streakEndDate: Date | null = null;
   let previousDate: Date | null = null;
   const oneDay: number = (24 * 60 * 60 * 1000) * 1;
   for (const td of tagDates) {
-    const index: number = tagDates.indexOf(td);
     if (previousDate != null) {
       // Determine if an actual (more than 1 day) streak started: Calculate the current tag 
       // mysteryTime minus one day, check if same date as previous array tag mysteryTime
@@ -140,13 +262,15 @@ function getPlayerTagLongestStreakData(
       tagDateMinusOneDay.setTime(td.getTime() - oneDay);
       if (getIsSameDay(tagDateMinusOneDay, previousDate)) {
         streakDaysCount++;
+        if (streakDaysCount === 2) {
+          // Current streak start
+          streakStartDate = previousDate;
+        }
         if (streakDaysCount >= streakDaysCountLongest) {
-          if (streakDaysCount === 2) {
-            // Current streak start
-            streakStartDate = previousDate;
-          }
-          // Current streak end
+          // Current longest streak start
+          streakLongestStartDate = streakStartDate;
           streakDaysCountLongest = streakDaysCount;
+          // Current longest streak end
           streakEndDate = td;
         }
       } else {
@@ -162,7 +286,7 @@ function getPlayerTagLongestStreakData(
   }
   const streakData: StreakData = {
     longestStreakDaysCount: streakDaysCountLongest,
-    longestStreakStartDate: streakStartDate,
+    longestStreakStartDate: streakLongestStartDate,
     longestStreakEndDate: streakEndDate,
   }
   return streakData;
@@ -174,18 +298,18 @@ interface PlayerStreakData {
 }
 
 /**
- * Get the players data with the longest streak of days tagged
+ * Get the players data with the longest daily tag streak
  * @param players The array of players
  * @returns Array of players data with longest streak of days tagged
  */
-function getPlayersDataWithLongestStreakDaysTagged(
+function getPlayersWithLongestDailyTagStreakData(
   players: Player[]
 ): PlayerStreakData[] {
   let longestStreakDays: number = 0;
   let playerRecord: PlayerStreakData;
   let playersData: PlayerStreakData[] = [];
   for (const player of players) {
-    const playerLongestStreakData = getPlayerTagLongestStreakData(player)
+    const playerLongestStreakData: StreakData = getTagLongestDailyStreakData(player.tags)
     if (playerLongestStreakData.longestStreakDaysCount > longestStreakDays) {
       longestStreakDays = playerLongestStreakData.longestStreakDaysCount;
     }
@@ -227,6 +351,17 @@ function getLongestTimeBetweenTags(
   return longestTimeBetweenTags;
 }
 
+interface StatsReportData {
+  playersWithMostTagsInOneDay: PlayerHighestNumberTagsPerDayData[],
+  playersWithLongestTagStreakDaysData: PlayerStreakData[],
+  gameTotalNumberOfPlayers: number,
+  gameTotalNumberOfTags: number,
+  gameHighestNumberTagsPerOneDayData: GameHighestNumberTagsPerNumberDaysData,
+  gameHighestNumberTagsPerSevenDaysData: GameHighestNumberTagsPerNumberDaysData,
+  gameLongestDailyTagStreakData: StreakData,
+  gameLongestTimeBetweenTags: number
+}
+
 const statsHandler: Handler = async (event) => {
   const biketagOpts = getBikeTagClientOpts(
     {
@@ -258,13 +393,13 @@ const statsHandler: Handler = async (event) => {
     source: 'imgur',
   })
 
-  // Player(s) with most tags in one day (total, time)
-  const playersWithMostTagsInOneDayData: {} = getPlayersWithHighestNumberTagsPerDayData(playersResponse.data)
+  // Player(s) with most tags in one day
+  const playersWithMostTagsInOneDayData: PlayerHighestNumberTagsPerDayData[] = getPlayersWithHighestNumberTagsPerDayData(playersResponse.data)
 
-  // Players with longest streak of days with a tag (total days, start time, end time)
-  const playersWithLongestTagStreakDaysData: {} = getPlayersDataWithLongestStreakDaysTagged(playersResponse.data)
+  // Player(s) with longest streak of daily tags
+  const playersWithLongestTagStreakDaysData: PlayerStreakData[] = getPlayersWithLongestDailyTagStreakData(playersResponse.data)
 
-  // Total number of players
+  // Game total number of players
   const totalNumberOfPlayers: number = playersResponse.data.length;
 
   // Get Tags data
@@ -272,8 +407,18 @@ const statsHandler: Handler = async (event) => {
     source: 'imgur',
   })
 
-  // Total number of tags
+  // Game total number of tags
   const totalNumberOfTags: number = tagsResponse.data.length;
+
+  // Game most tags in one day
+  const gameHighestNumberTagsPerOneDayData: GameHighestNumberTagsPerNumberDaysData = getGameHighestNumberTagsPerNumberDaysData(tagsResponse.data);
+
+  // Game most tags in one week
+  const days = 7;
+  const gameHighestNumberTagsPerSevenDaysData: GameHighestNumberTagsPerNumberDaysData = getGameHighestNumberTagsPerNumberDaysData(tagsResponse.data, days);
+
+  // Game longest streak of daily tags
+  const gameLongestDailyTagStreakData: StreakData = getTagLongestDailyStreakData(tagsResponse.data)
 
   // Longest time between tags
   const longestTimeBetweenTags: number = getLongestTimeBetweenTags(tagsResponse.data);
@@ -283,12 +428,15 @@ const statsHandler: Handler = async (event) => {
     statusCode = 200;
   }
   const success = playersResponse.success && tagsResponse.success;
-  const data = {
-    'playersWithMostTagsInOneDay': playersWithMostTagsInOneDayData,
-    'playersWithLongestTagStreakDaysData': playersWithLongestTagStreakDaysData,
-    'totalNumberOfPlayers': totalNumberOfPlayers,
-    'totalNumberOfTags': totalNumberOfTags,
-    'longestTimeBetweenTags': longestTimeBetweenTags
+  const data: StatsReportData = {
+    playersWithMostTagsInOneDay: playersWithMostTagsInOneDayData,
+    playersWithLongestTagStreakDaysData: playersWithLongestTagStreakDaysData,
+    gameTotalNumberOfPlayers: totalNumberOfPlayers,
+    gameTotalNumberOfTags: totalNumberOfTags,
+    gameHighestNumberTagsPerOneDayData: gameHighestNumberTagsPerOneDayData,
+    gameHighestNumberTagsPerSevenDaysData: gameHighestNumberTagsPerSevenDaysData,
+    gameLongestDailyTagStreakData: gameLongestDailyTagStreakData,
+    gameLongestTimeBetweenTags: longestTimeBetweenTags
   }
   const statsResponse: {} = {
     'data': data,

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -78,8 +78,8 @@ function getGameHighestNumberTagsPerNumberDaysData(
   let tagsPerNumberDaysData: GameHighestNumberTagsPerNumberDaysData = {
     tagCount: tagsPerNumberDaysHighest,
     dayCount: days,
-    startDate: previousTagDate,
-    endDate: previousTagDate
+    startDate: null,
+    endDate: null
   }
   const oneDay: number = (24 * 60 * 60 * 1000) * 1;
   const daysBack: number[] = [...Array(days).keys()];

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -1,0 +1,247 @@
+import { builder, Handler } from '@netlify/functions'
+import { BikeTagClient } from 'biketag'
+import { getPlayersPayload, getTagsPayload } from 'biketag/dist/common/payloads'
+import { Game, Player } from 'biketag/dist/common/schema'
+import request from 'request'
+import { getBikeTagClientOpts, getPayloadOpts } from './common'
+import { getTagDate } from '../src/common'
+
+/**
+ * Check if two date objects are on the same date
+ * @param d1 Date 1
+ * @param d2 Date 2
+ * @returns True if dates are the same
+ */
+function getIsSameDay(
+  d1: Date,
+  d2: Date
+): boolean {
+  return d1.getFullYear() === d2.getFullYear() &&
+    d1.getMonth() === d2.getMonth() &&
+    d1.getDate() === d2.getDate();
+}
+
+/**
+ * Get player's highest number of tags in one day data
+ * @param player Player to get highest number of tags in one day data
+ * @returns Highest number of tags per day data
+ */
+function getPlayerHighestNumberTagsPerDayData(
+  player: Player
+): {} {
+  let tagsPerDayData : {} = {
+    'tagCount': 0,
+    'tagDate': new Date()
+  };
+  let tagsPerDay : number = 1;
+  let tagsPerDayHighest : number = 1;
+  let previousTagDate : Date | null = null;
+  for (const tag of player.tags) {
+    const tagDate : Date = getTagDate(tag.mysteryTime);
+    if (previousTagDate != null && getIsSameDay(tagDate, previousTagDate)) {
+      tagsPerDay++;
+    } else {
+      tagsPerDay = 1;
+    }
+    if (tagsPerDay > tagsPerDayHighest) {
+      tagsPerDayData = {
+        'tagCount': tagsPerDay,
+        'tagDate': tagDate
+      }
+    }
+    previousTagDate = tagDate;
+  }
+  return tagsPerDayData;
+}
+
+/**
+ * Get the players with the highest number of tags in one day data
+ * @param players Players to get highest number of tags in one day data
+ * @returns Count for highest number of tags in one day
+ */
+function getPlayersWithHighestNumberTagsPerDayData(
+  players: Player[]
+): Array<{}> {
+  let tagsPerDayHighest : number = 0;
+  let tagsPerDayData : Array<{}> = [];
+  for (const player of players) {
+    const tagsPerDayRecord : {} = getPlayerHighestNumberTagsPerDayData(player);
+    tagsPerDayData.push(tagsPerDayRecord);
+    if (tagsPerDayRecord['tagCount'] > tagsPerDayHighest) {
+      tagsPerDayHighest = tagsPerDayRecord['tagCount'];
+    }
+  }
+  let highestTagsPerDayData : Array<{}> = [];
+  for (const tpdr of tagsPerDayData) {
+    if (tpdr['tagCount'] >= tagsPerDayHighest) {
+      highestTagsPerDayData.push(tpdr);
+    }
+  }
+  return highestTagsPerDayData;
+}
+
+/**
+ * Get the player's unique tag dates
+ * @param player Player to get unique tag dates
+ * @returns Array of unique tag dates
+ */
+function getPlayerUniqueTagDates(
+  player: Player
+): Date[] {
+  let uniqueTagDates : Date[] = [];
+  for (const tag of player.tags) {
+      const tagDate : Date = getTagDate(tag.mysteryTime);
+      if (uniqueTagDates.length === 0) {
+        uniqueTagDates.push(tagDate);
+      } else {
+        for (const utd of uniqueTagDates) {
+          if (!getIsSameDay(utd, tagDate)) {
+            uniqueTagDates.push(tagDate);
+          }
+        }
+      }
+    }
+  return uniqueTagDates;
+}
+
+/**
+ * Get the player's longest streak of days with a tag data
+ * @param player Player to get longest streak of days with a tag data
+ * @returns Object containing longest streak days count, streak start date, streak end date
+ */
+function getPlayerTagLongestStreakData(
+  player: Player
+): {} {
+  let tagDates : Date[] = getPlayerUniqueTagDates(player);
+  tagDates.sort((a, b) => a.getTime() - b.getTime());
+
+  let streakData : {} = {};
+  let streakStartDate : Date | null = null;
+  let streakEndDate : Date | null = null;
+  let streakDays : number = 1;
+  for (const td of tagDates) {
+    const tagDatePlusOneDay : Date = new Date(td.getDate() + 1);
+    const index : number = tagDates.indexOf(td);
+    const indexPlusOneDate = tagDates[index+1]
+    if (tagDatePlusOneDay === indexPlusOneDate) {
+      streakEndDate = indexPlusOneDate;
+      streakDays++;
+    } else {
+      streakStartDate = td;
+      streakDays = 1;
+    }
+  }
+  streakData = {
+    'longestStreakDaysCount': streakDays,
+    'longestStreakStartDate': streakStartDate,
+    'longestStreakEndDate': streakEndDate,
+  }
+  return streakData;
+}
+
+
+/**
+ * Get the players data with the longest streak of days tagged
+ * @param players The array of players
+ * @returns Array of players data with longest streak of days tagged
+ */
+function getPlayersDataWithLongestStreakDaysTagged(
+  players: Player[]
+): Array<{}> {
+  let longestStreakDays : number = 0;
+  let playerRecord : {};
+  let playersData : Array<{}> = [];
+  for (const player of players) {
+    const playerLongestStreakData = getPlayerTagLongestStreakData(player)
+    if (playerLongestStreakData['streakDaysCount'] > longestStreakDays) {
+      longestStreakDays = playerLongestStreakData['longestStreakDaysCount'];
+    }
+    playerRecord = {
+      'player': player,
+      'longestStreakData': playerLongestStreakData
+    }
+    playersData.push(playerRecord);
+  }
+  let longestStreakPlayersData : Array<{}> = [];
+  for (const pd of playersData) {
+    if (pd['longestStreakDays'] >= longestStreakDays) {
+      longestStreakPlayersData.push(pd);
+    }
+  }
+  return longestStreakPlayersData;
+}
+
+const statsHandler: Handler = async (event) => {
+  const biketagOpts = getBikeTagClientOpts(
+    {
+      ...event,
+      method: event.httpMethod,
+    } as unknown as request.Request,
+    true,
+  )
+  const biketag = new BikeTagClient(biketagOpts)
+  const game = (await biketag.game(biketagOpts.game, {
+    source: 'sanity',
+    concise: true,
+  })) as unknown as Game
+  const biketagPayload = getPayloadOpts(event, {
+    imgur: {
+      hash: game.mainhash,
+    },
+    game: biketagOpts.game,
+  })
+
+  // Get Players data
+  const playersResponse = await biketag.getPlayers(biketagPayload as getPlayersPayload, {
+    source: 'imgur',
+  })
+  console.log(`getPlayers response: ${playersResponse}`);
+
+  // Player(s) with most tags in one day (total, time)
+  const playersWithMostTagsInOneDayData : {} = getPlayersWithHighestNumberTagsPerDayData(playersResponse.data)
+
+  // Players with longest streak of days with a tag (total days, start time, end time)
+  const playersWithLongestTagStreakDaysData : {} = getPlayersDataWithLongestStreakDaysTagged(playersResponse.data)
+
+  // Total number of players
+  const totalNumberOfPlayers : number = playersResponse.data.length;
+
+  // Get Tags data
+  const tagsResponse = await biketag.getTags(biketagPayload as getTagsPayload, {
+    source: 'imgur',
+  })
+  console.log(`getTags response: ${tagsResponse}`);
+
+  // Total number of tags
+  const totalNumberOfTags : number = tagsResponse.data.length;
+
+  // Longest time between tags
+  // TODO
+  const longestTimeBetweenTags : null = null;
+
+  let statusCode : number = 400;
+  if (playersResponse.status === 200 && tagsResponse.status === 200) {
+    statusCode = 200;
+  }
+  const success = playersResponse.success && tagsResponse.success;
+  const data = {
+    'playersWithMostTagsInOneDay': playersWithMostTagsInOneDayData,
+    'playersWithLongestTagStreakDaysData': playersWithLongestTagStreakDaysData,
+    'totalNumberOfPlayers': totalNumberOfPlayers,
+    'totalNumberOfTags': totalNumberOfTags,
+    'longestTimeBetweenTags': longestTimeBetweenTags
+  }
+  const statsResponse : {} = {
+    'data': data,
+    'success': success,
+    'error': !success ? 'Something went wrong' : undefined,
+  }
+  return {
+    statusCode: statusCode,
+    body: JSON.stringify(success ? data : statsResponse),
+  }
+}
+
+const handler = builder(statsHandler)
+
+export { handler }

--- a/functions/stats.ts
+++ b/functions/stats.ts
@@ -1,7 +1,7 @@
 import { builder, Handler } from '@netlify/functions'
 import { BikeTagClient } from 'biketag'
 import { getPlayersPayload, getTagsPayload } from 'biketag/dist/common/payloads'
-import { Game, Player } from 'biketag/dist/common/schema'
+import { Game, Player, Tag } from 'biketag/dist/common/schema'
 import request from 'request'
 import { getBikeTagClientOpts, getPayloadOpts } from './common'
 import { getTagDate } from '../src/common'
@@ -114,25 +114,36 @@ function getPlayerTagLongestStreakData(
 ): {} {
   let tagDates : Date[] = getPlayerUniqueTagDates(player);
   tagDates.sort((a, b) => a.getTime() - b.getTime());
-
-  let streakData : {} = {};
+  let streakDaysCount : number | null = null;
   let streakStartDate : Date | null = null;
   let streakEndDate : Date | null = null;
-  let streakDays : number = 1;
+  let onStreak : boolean = false;
   for (const td of tagDates) {
-    const tagDatePlusOneDay : Date = new Date(td.getDate() + 1);
+    const tagDateMinusOneDay : Date = new Date(td.getDate() - 1);
     const index : number = tagDates.indexOf(td);
-    const indexPlusOneDate = tagDates[index+1]
-    if (tagDatePlusOneDay === indexPlusOneDate) {
-      streakEndDate = indexPlusOneDate;
-      streakDays++;
+    if (index === 0) {
+      continue;
     } else {
-      streakStartDate = td;
-      streakDays = 1;
+      const indexMinusOneDate = tagDates[index-1]
+      if (getIsSameDay(tagDateMinusOneDay, indexMinusOneDate)) {
+        if (!onStreak) {
+          streakStartDate = indexMinusOneDate;
+        }
+        streakEndDate = td;
+        onStreak = true;
+      } else {
+        onStreak = false;
+      }
     }
   }
-  streakData = {
-    'longestStreakDaysCount': streakDays,
+  if (streakStartDate != null && streakEndDate != null) {
+    const oneDay = 24 * 60 * 60 * 1000;
+    const diffTime = streakEndDate.getTime() - streakStartDate.getTime();
+    streakDaysCount = Math.round(diffTime / oneDay) + 1;
+  }
+
+  const streakData : {} = {
+    'longestStreakDaysCount': streakDaysCount,
     'longestStreakStartDate': streakStartDate,
     'longestStreakEndDate': streakEndDate,
   }
@@ -169,6 +180,30 @@ function getPlayersDataWithLongestStreakDaysTagged(
     }
   }
   return longestStreakPlayersData;
+}
+
+/**
+ * Get the longest time between tags
+ * @param tags The array of tags
+ * @returns Time between tags
+ */
+function getLongestTimeBetweenTags(
+  tags: Tag[]
+): number {
+  let longestTimeBetweenTags : number = 0;
+  let previousTag : Tag | null = null;
+  for (const tag of tags) {
+    if (longestTimeBetweenTags === 0) {
+      continue;
+    } else {
+      const timeBetweenTags : number = tag.mysteryTime - previousTag.mysteryTime
+      if (timeBetweenTags > longestTimeBetweenTags) {
+        longestTimeBetweenTags = timeBetweenTags;
+      }
+    }
+    previousTag = tag;
+  }
+  return longestTimeBetweenTags;
 }
 
 const statsHandler: Handler = async (event) => {
@@ -216,8 +251,7 @@ const statsHandler: Handler = async (event) => {
   const totalNumberOfTags : number = tagsResponse.data.length;
 
   // Longest time between tags
-  // TODO
-  const longestTimeBetweenTags : null = null;
+  const longestTimeBetweenTags : number = getLongestTimeBetweenTags(tagsResponse.data);
 
   let statusCode : number = 400;
   if (playersResponse.status === 200 && tagsResponse.status === 200) {


### PR DESCRIPTION
The stats endpoint should provide stats for a given game that include:

    Highest number of tags per day (amount, date)
    longest streak of daily tags (amount of days, date range)
    total number of players
    total number of tags
    longest time between tags



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new endpoint providing detailed game statistics, including top players by tags in a day, longest tagging streaks, total player and tag counts, and the longest interval between tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->