### PR TITLE
feat(about page): add social links to common external platforms for B…

### DIFF
--- a/public/docs/about-socials.html
+++ b/public/docs/about-socials.html
@@ -1,0 +1,5 @@
+<p>
+    BikeTag itself does not host social interactions between users. Community discourse is held through external websites such as Reddit, Slack, and regional Instagrams. 
+    <br />
+    Below are links to some of the social platforms dedicated to BikeTag.
+</p>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -233,6 +233,11 @@
         "privacy_policy": "Read the Privacy Policy",
         "code_of_conduct": "Read the Code of Conduct",
         "organization": "Read about the BikeTag Project Organization"
+      },
+      "about-socials": {
+        "title": "Social Media Outlets",
+        "reddit": "/r/BikeTag",
+        "slack": "Slack"
       }
     },
     "approve": {

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -45,6 +45,30 @@
           </bike-tag-button>
         </p>
       </div>
+      <div class="about__block">
+        <h3>
+          {{ $t('pages.about.about-socials.title') }}
+        </h3>
+        <hr class="about__hr" :style="`background-image: url(${styledHr})`" />
+        <section-content filename="docs/about-socials.html" />
+        <p>
+          <bike-tag-button
+            variant="medium-orange"
+            class="m-1 big-btn"
+            onclick="window.open('https://www.reddit.com/r/biketag/')"
+          >
+            {{ $t('pages.about.about-socials.reddit') }}
+            <img class="about__icon" :src="Reddit" alt="about" />
+          </bike-tag-button>
+          <bike-tag-button
+            variant="medium-orange"
+            class="m-1 big-btn"
+            onclick="window.open('https://biketag.slack.com/signup#/domain-signup')"
+          >
+            {{ $t('pages.about.about-socials.slack') }}
+          </bike-tag-button>
+        </p>
+      </div>
       <bike-tag-map variant="worldwide" />
       <bike-tag-games class="mt-5 mb-5" />
       <div class="about__block">
@@ -126,6 +150,7 @@ import Donate from '@/assets/images/donate.svg'
 import StyledHr from '@/assets/images/hr.svg'
 import Pin from '@/assets/images/pin.svg'
 import Profile from '@/assets/images/profile-icon.svg'
+import Reddit from '@/assets/images/Reddit.svg'
 import { ref } from 'vue'
 
 // components


### PR DESCRIPTION
- **New Feature**
  - Added a new socials section to the about page that provides links to commonly used social media platforms for the BikeTag community.
- **TODO**
  - Still needs artwork done.
  - I am unsure what other social platforms are commonly used that could be added.

This is intended to resolve Issue #246 (or at least be a starting point).

I'm a new contributor and also very new to contributing in general. Let me know if there are any changes I need to make to the code or PR process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new section on the About page highlighting BikeTag's social media presence, including links to Reddit and Slack communities.
  - Introduced visually styled buttons for easy access to external BikeTag social platforms.
- **Documentation**
  - Updated documentation to clarify that social interactions occur on external platforms, with direct links provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->