### PR TITLE
fix(biketagmap.vue): fix map icon anchor issue

### DIFF
--- a/src/components/BikeTagMap.vue
+++ b/src/components/BikeTagMap.vue
@@ -36,6 +36,7 @@ const worldZoom = 3
 const cityZoom = 10
 const playZoom = 15
 const centerNorthAmerica = [40, -45]
+const markerHeight = 50
 let map
 
 // computed
@@ -48,33 +49,30 @@ const getMarkers = computed(() =>
     ? getTags.value.map((t) => ({
         point: [t.gps.lat ?? 0, t.gps.long ?? t.gps.lng ?? 0],
         logo: Pin,
+        size: [markerHeight, markerHeight],
+        anchor: [markerHeight/2, markerHeight]
       }))
     : getAllGames.value
         .filter((game) => !!game.boundary.lat) // add gps location to all games
-        .map((game) => ({ point: game.boundary, logo: getLogoUrl.value('', game.logo) })),
+        .map((game) => ({
+          point: game.boundary,
+          logo: getLogoUrl.value('', game.logo),
+          size: ['auto', markerHeight],
+          anchor: [0, markerHeight]
+        })),
 )
 
 const mapContainer = ref(null)
 const gameCenter = ref(centerNorthAmerica)
 
-const LeafIcon = L.Icon.extend({
-  options: {
-    iconSize: ['auto', 50],
-    iconAnchor: [0, 50],
-  },
-})
-
-const MarkerIcon = L.Icon.extend({
-  options: {
-    iconSize: ['auto', 50],
-    iconAnchor: [30, 50],
-  },
-})
-
 const addMarkers = () => {
   for (let i = 0; i < getMarkers.value.length; i++) {
     L.marker(getMarkers.value[i].point, {
-      icon: new LeafIcon({ iconUrl: getMarkers.value[i].logo }),
+      icon: new L.Icon({
+        iconUrl: getMarkers.value[i].logo,
+        iconSize: getMarkers.value[i].size,
+        iconAnchor: getMarkers.value[i].anchor
+      }),
     }).addTo(map)
   }
 }
@@ -110,7 +108,11 @@ onMounted(async () => {
 
   if (props.variant == 'play/input') {
     const marker = L.marker(props.start, {
-      icon: new MarkerIcon({ iconUrl: Pin }),
+      icon: new L.Icon({
+        iconUrl: Pin,
+        iconSize: [markerHeight, markerHeight],
+        iconAnchor: [markerHeight/2, markerHeight]
+      }),
       draggable: true,
     }).addTo(map)
     L.control.locate().addTo(map)


### PR DESCRIPTION
Fixes a visual issue on the map page where biketag pins appear to 'drift' as the user zooms in and out

Before (zoomed in):


<img width="1920" height="1032" alt="Screenshot from 2025-12-03 16-39-08" src="https://github.com/user-attachments/assets/8f03e883-6688-4e15-bba7-401661dbc4af" />

Before (zoomed out):

<img width="1920" height="1032" alt="Screenshot from 2025-12-03 16-39-18" src="https://github.com/user-attachments/assets/70277454-1ea2-43d1-befc-2f5821a68b25" />


After (zoomed in):

<img width="1920" height="1032" alt="Screenshot from 2025-12-03 16-37-37" src="https://github.com/user-attachments/assets/857434ce-870a-4526-8fdb-1503427fa74b" />

After (zoomed out):

<img width="1920" height="1032" alt="Screenshot from 2025-12-03 16-38-43" src="https://github.com/user-attachments/assets/4e99000f-ffc7-4814-86de-239ebdb5f096" />